### PR TITLE
feat: add dark mode support

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -54,6 +54,13 @@ html, body {
 	background-color: var(--color-divider);
 }
 
+#doc img {
+	padding: 12px;
+	background-color: #fff;
+	border: 1px solid var(--color-divider);
+	border-radius: 3px;
+}
+
 /*
 	Tables
 */

--- a/css/global.css
+++ b/css/global.css
@@ -4,6 +4,7 @@
 :root {
   --color-anchor: #337ab7;
   --color-bg: #fff;
+  --color-blockquote-text: #777;
   --color-code-bg: #f7f7f7;
   --color-code-text: #333;
   --color-divider: #cdcdcd;
@@ -22,6 +23,7 @@
 html.dark {
   --color-anchor: #77e1cd;
   --color-bg: #1c1c1c;
+  --color-blockquote-text: #868686;
   --color-code-bg: #313030;
   --color-code-text: #fefefe;
   --color-divider: #8b8b8b;
@@ -62,8 +64,10 @@ html, body {
   background-color: var(--color-divider);
 }
 
-#doc blockquote {
+#doc blockquote, .markdown-body blockquote,
+#doc blockquote *, .markdown-body blockquote * {
   border-color: var(--color-divider);
+  color: var(--color-blockquote-text);
 }
 
 /*

--- a/css/global.css
+++ b/css/global.css
@@ -23,7 +23,7 @@
 html.dark {
   --color-anchor: #77e1cd;
   --color-bg: #1c1c1c;
-  --color-blockquote-text: #868686;
+  --color-blockquote-text: #c0bcbc;
   --color-code-bg: #313030;
   --color-code-text: #fefefe;
   --color-divider: #8b8b8b;

--- a/css/global.css
+++ b/css/global.css
@@ -84,13 +84,13 @@ html, body {
 	- Optional: add 'invert' class to the image for dark mode inversion
 */
 #doc img {
+	box-sizing: border-box;
 	border: 1px solid var(--color-divider);
 	border-radius: 3px;
 }
 
 #doc img.padded {
 	padding: 12px;
-	background-color: #fff;
 }
 
 html.dark #doc img.invert {

--- a/css/global.css
+++ b/css/global.css
@@ -7,7 +7,7 @@
 	--color-heading: #333;
 	--color-divider: #e2e2e2;
 	--color-anchor: #337ab7;
-	--color-toggle-checked: #9740f6;
+	--color-toggle-accent: #c3a554;
 	--color-table-row-header: #e8e6e6;
 	--color-table-row-odd: #fbfbfb;
 	--color-table-row-even: #f0f0f0;
@@ -23,6 +23,7 @@ html.dark {
 	--color-heading: #dfdfdf;
 	--color-divider: #8b8b8b;
 	--color-anchor: #77e1cd;
+	--color-toggle-accent: #a076ce;
 	--color-table-row-header: #000;
 	--color-table-row-odd: #333333;
 	--color-table-row-even: #181818;
@@ -103,6 +104,12 @@ html.dark #doc img.invert {
 	margin-right: 8px;
 }
 
+#color-mode-switch svg {
+	width: 24px;
+	height: 24px;
+	margin: 0 4px;
+}
+
 #color-mode-switch input[type=checkbox] {
 	height: 0;
 	width: 0;
@@ -112,11 +119,11 @@ html.dark #doc img.invert {
 #color-mode-switch label {
 	cursor: pointer;
 	text-indent: -9999px;
-	width: 60px;
-	height: 30px;
-	background: #a5a5a5;
-	display: block;
+	width: 42px;
+	height: 21px;
 	border-radius: 30px;
+	background: var(--color-toggle-accent);
+	display: block;
 	position: relative;
 	margin: 0;
 }
@@ -124,47 +131,20 @@ html.dark #doc img.invert {
 #color-mode-switch label:after {
 	content: '';
 	position: absolute;
-	top: 5px;
-	left: 5px;
-	width: 20px;
-	height: 20px;
+	top: 3px;
+	left: 3px;
+	width: 15px;
+	height: 15px;
 	background: #fff;
 	border-radius: 90px;
 	transition: 0.3s;
 }
 
-#color-mode-switch input:checked + label {
-	background: var(--color-toggle-checked);
-}
-
 #color-mode-switch input:checked + label:after {
-	left: calc(100% - 5px);
+	left: calc(100% - 3px);
 	transform: translateX(-100%);
 }
 
 #color-mode-switch label:active:after {
 	width: 30px;
-}
-
-@media screen and (min-width: 1273px) {
-	#color-mode-switch > span {
-		font-size: 16px;
-	}
-
-	#color-mode-switch label {
-		width: 42px;
-		height: 21px;
-		border-radius: 30px;
-	}
-
-	#color-mode-switch label:after {
-		top: 3px;
-		left: 3px;
-		width: 15px;
-		height: 15px;
-	}
-
-	#color-mode-switch input:checked + label:after {
-		left: calc(100% - 3px);
-	}
 }

--- a/css/global.css
+++ b/css/global.css
@@ -7,6 +7,8 @@
   --color-heading: #333;
   --color-anchor: #337ab7;
   --color-divider: #cdcdcd;
+  --color-code-bg: #f7f7f7;
+  --color-code-text: #333;
   --color-toggle-accent: #c3a554;
   --color-table-row-header: #e8e6e6;
   --color-table-row-odd: #fbfbfb;
@@ -23,6 +25,8 @@ html.dark {
   --color-heading: #dfdfdf;
   --color-anchor: #77e1cd;
   --color-divider: #8b8b8b;
+  --color-code-bg: #313030;
+  --color-code-text: #fefefe;
   --color-toggle-accent: #a076ce;
   --color-table-row-header: #000;
   --color-table-row-odd: #333333;
@@ -36,6 +40,16 @@ html.dark {
 html, body {
   background-color: var(--color-bg);
   color: var(--color-text);
+}
+
+/*
+  Code blocks and formatted text
+*/
+.markdown-body code, .markdown-body code *,
+#doc pre, #doc code, #doc pre code,
+#doc pre *, #doc code *, #doc pre code * {
+  background-color: var(--color-code-bg);
+  color: var(--color-code-text);
 }
 
 #doc h1, #doc h2, #doc h3, #doc h4, #doc h5, #doc h6 {

--- a/css/global.css
+++ b/css/global.css
@@ -1,24 +1,37 @@
-
-/* Light Mode Colors */
+/*
+	Light Color Scheme
+*/
 :root {
 	--color-text: #333;
 	--color-bg: #fafafa;
 	--color-heading: #333;
-	--color-divider: #e7e7e7;
+	--color-divider: #e2e2e2;
 	--color-anchor: #337ab7;
 	--color-toggle-checked: #9740f6;
+	--color-table-row-header: #e8e6e6;
+	--color-table-row-odd: #fbfbfb;
+	--color-table-row-even: #f0f0f0;
+	--color-table-border: #c2c2c2;
 }
 
-/* Dark Mode Colors */
+/*
+	Dark Color Scheme
+*/
 html.dark {
 	--color-text: #fafafa;
 	--color-bg: #1c1c1c;
 	--color-heading: #dfdfdf;
-	--color-divider: #393939;
+	--color-divider: #8b8b8b;
 	--color-anchor: #77e1cd;
+	--color-table-row-header: #000;
+	--color-table-row-odd: #333333;
+	--color-table-row-even: #181818;
+	--color-table-border: #767676;
 }
 
-/* Global colors */
+/*
+	Apply colors to general doc selectors
+*/
 html, body {
 	background-color: var(--color-bg);
 	color: var(--color-text);
@@ -26,6 +39,7 @@ html, body {
 
 #doc h1, #doc h2, #doc h3, #doc h4, #doc h5, #doc h6 {
 	color: var(--color-heading);
+	border-color: var(--color-divider);
 }
 
 #doc, #doc div, #doc span, #doc p, #doc li, #doc th, #doc td, #doc dd, #doc dl {
@@ -36,11 +50,40 @@ html, body {
 	color: var(--color-anchor);
 }
 
-.markdown-body hr {
+#doc hr {
 	background-color: var(--color-divider);
 }
 
-/* Light/Dark Mode Toggle */
+/*
+	Tables
+*/
+#doc table thead tr, #doc table tr.header {
+	background-color: var(--color-table-row-header);
+}
+
+#doc table tbody tr, #doc table tr.odd {
+	background-color: var(--color-table-row-odd);
+}
+
+#doc table tbody tr:nth-child(2n), #doc table tr.even {
+	background-color: var(--color-table-row-even);
+}
+
+#doc table th, #doc table td {
+	border-color: var(--color-table-border);
+}
+
+/*
+	Dark Mode Images
+	- Optional: add 'invert' class to the image for dark mode inversion
+*/
+html.dark #doc img.invert {
+	filter: invert(1)
+}
+
+/*
+	Color Scheme Toggle Switch
+*/
 #color-mode-switch {
 	display: flex;
 	align-items: center;
@@ -64,7 +107,7 @@ html, body {
 	text-indent: -9999px;
 	width: 60px;
 	height: 30px;
-	background: grey;
+	background: #a5a5a5;
 	display: block;
 	border-radius: 30px;
 	position: relative;
@@ -113,7 +156,6 @@ html, body {
 		width: 15px;
 		height: 15px;
 	}
-
 
 	#color-mode-switch input:checked + label:after {
 		left: calc(100% - 3px);

--- a/css/global.css
+++ b/css/global.css
@@ -1,37 +1,37 @@
 /*
-  Light Color Scheme
+  Light Mode Color Scheme
 */
 :root {
-  --color-bg: #fff;
-  --color-text: #333;
-  --color-heading: #333;
   --color-anchor: #337ab7;
-  --color-divider: #cdcdcd;
+  --color-bg: #fff;
   --color-code-bg: #f7f7f7;
   --color-code-text: #333;
-  --color-toggle-accent: #c3a554;
+  --color-divider: #cdcdcd;
+  --color-heading: #333;
+  --color-table-border: #c2c2c2;
+  --color-table-row-even: #f0f0f0;
   --color-table-row-header: #e8e6e6;
   --color-table-row-odd: #fbfbfb;
-  --color-table-row-even: #f0f0f0;
-  --color-table-border: #c2c2c2;
+  --color-toggle-accent: #c3a554;
+  --color-text: #333;
 }
 
 /*
-  Dark Color Scheme
+  Dark Mode Color Scheme
 */
 html.dark {
-  --color-bg: #1c1c1c;
-  --color-text: #fafafa;
-  --color-heading: #dfdfdf;
   --color-anchor: #77e1cd;
-  --color-divider: #8b8b8b;
+  --color-bg: #1c1c1c;
   --color-code-bg: #313030;
   --color-code-text: #fefefe;
-  --color-toggle-accent: #a076ce;
+  --color-divider: #8b8b8b;
+  --color-heading: #dfdfdf;
+  --color-table-border: #767676;
+  --color-table-row-even: #181818;
   --color-table-row-header: #000;
   --color-table-row-odd: #333333;
-  --color-table-row-even: #181818;
-  --color-table-border: #767676;
+  --color-toggle-accent: #a076ce;
+  --color-text: #fafafa;
 }
 
 /*
@@ -43,15 +43,8 @@ html, body {
 }
 
 /*
-  Code blocks and formatted text
+  Typography & doc elements
 */
-.markdown-body code, .markdown-body code *,
-#doc pre, #doc code, #doc pre code,
-#doc pre *, #doc code *, #doc pre code * {
-  background-color: var(--color-code-bg);
-  color: var(--color-code-text);
-}
-
 #doc h1, #doc h2, #doc h3, #doc h4, #doc h5, #doc h6 {
   color: var(--color-heading);
   border-color: var(--color-divider);
@@ -74,8 +67,49 @@ html, body {
 }
 
 /*
+  Code blocks and formatted text
+*/
+.markdown-body code, .markdown-body code *,
+#doc pre, #doc code, #doc pre code,
+#doc pre *, #doc code *, #doc pre code * {
+  background-color: var(--color-code-bg);
+  color: var(--color-code-text);
+}
+
+/*
+  Images
+  - Optional: add 'transparent' class to remove the border & background
+    - The image will inherit the light/dark mode background color
+    - Useful to preserve transparent background images/icons
+  - Optional: add 'padded' class to give extra padding to an image
+    - Very useful for graphs and charts
+  - Optional: add 'invert' class to the image for dark mode inversion
+    - Used to completely invert the colors of an image while in dark mode
+*/
+#doc img {
+  border: none;
+  border-radius: 3px;
+  box-sizing: border-box;
+}
+
+#doc img.transparent {
+  background-color: transparent;
+  border: none;
+}
+
+#doc img.padded {
+  padding: 12px;
+}
+
+html.dark #doc img.invert {
+  filter: invert(1)
+}
+
+/*
   Tables
-  - Optional: add 'transparent' class to create an invisible table, remove borders, striping and background, usually for tablegird layouts
+  - Normal tables are striped styled
+  - Optional: add 'transparent' class to create an invisible table, remove borders, striping and background
+    - Useful for when using tables for grid layouts
   - Optional: add 'centered' class to center align all the text within the table
 */
 #doc table thead tr, #doc table tr.header {
@@ -108,31 +142,6 @@ html, body {
 #doc table.centered th,
 #doc table.centered td {
   text-align: center;
-}
-
-/*
-  Images
-  - Optional: add 'transparent' class to remove the border & background, useful to preserve transparent background images/icons
-  - Optional: add 'padded' class to give extra padding to an image
-  - Optional: add 'invert' class to the image for dark mode inversion
-*/
-#doc img {
-  border: none;
-  border-radius: 3px;
-  box-sizing: border-box;
-}
-
-#doc img.transparent {
-  background-color: transparent;
-  border: none;
-}
-
-#doc img.padded {
-  padding: 12px;
-}
-
-html.dark #doc img.invert {
-  filter: invert(1)
 }
 
 /*

--- a/css/global.css
+++ b/css/global.css
@@ -2,7 +2,7 @@
   Light Color Scheme
 */
 :root {
-  --color-bg: #fafafa;
+  --color-bg: #fff;
   --color-text: #333;
   --color-heading: #333;
   --color-anchor: #337ab7;
@@ -103,14 +103,14 @@ html, body {
   - Optional: add 'invert' class to the image for dark mode inversion
 */
 #doc img {
-  box-sizing: border-box;
-  border: 1px solid var(--color-divider);
+  border: none;
   border-radius: 3px;
+  box-sizing: border-box;
 }
 
 #doc img.transparent {
-  border: none;
   background-color: transparent;
+  border: none;
 }
 
 #doc img.padded {

--- a/css/global.css
+++ b/css/global.css
@@ -1,0 +1,121 @@
+
+/* Light Mode Colors */
+:root {
+	--color-text: #333;
+	--color-bg: #fafafa;
+	--color-heading: #333;
+	--color-divider: #e7e7e7;
+	--color-anchor: #337ab7;
+	--color-toggle-checked: #9740f6;
+}
+
+/* Dark Mode Colors */
+html.dark {
+	--color-text: #fafafa;
+	--color-bg: #1c1c1c;
+	--color-heading: #dfdfdf;
+	--color-divider: #393939;
+	--color-anchor: #77e1cd;
+}
+
+/* Global colors */
+html, body {
+	background-color: var(--color-bg);
+	color: var(--color-text);
+}
+
+#doc h1, #doc h2, #doc h3, #doc h4, #doc h5, #doc h6 {
+	color: var(--color-heading);
+}
+
+#doc, #doc div, #doc span, #doc p, #doc li, #doc th, #doc td, #doc dd, #doc dl {
+	color: var(--color-text);
+}
+
+#doc a:link, #doc a:visited, #doc a:active, #doc a:checked {
+	color: var(--color-anchor);
+}
+
+.markdown-body hr {
+	background-color: var(--color-divider);
+}
+
+/* Light/Dark Mode Toggle */
+#color-mode-switch {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+}
+
+#color-mode-switch > span {
+	font-size: 30px;
+	display: inline-block;
+	margin-right: 8px;
+}
+
+#color-mode-switch input[type=checkbox] {
+	height: 0;
+	width: 0;
+	visibility: hidden;
+}
+
+#color-mode-switch label {
+	cursor: pointer;
+	text-indent: -9999px;
+	width: 60px;
+	height: 30px;
+	background: grey;
+	display: block;
+	border-radius: 30px;
+	position: relative;
+	margin: 0;
+}
+
+#color-mode-switch label:after {
+	content: '';
+	position: absolute;
+	top: 5px;
+	left: 5px;
+	width: 20px;
+	height: 20px;
+	background: #fff;
+	border-radius: 90px;
+	transition: 0.3s;
+}
+
+#color-mode-switch input:checked + label {
+	background: var(--color-toggle-checked);
+}
+
+#color-mode-switch input:checked + label:after {
+	left: calc(100% - 5px);
+	transform: translateX(-100%);
+}
+
+#color-mode-switch label:active:after {
+	width: 30px;
+}
+
+@media screen and (min-width: 1273px) {
+	#color-mode-switch > span {
+		font-size: 16px;
+	}
+
+	#color-mode-switch label {
+		width: 42px;
+		height: 21px;
+		border-radius: 30px;
+	}
+
+	#color-mode-switch label:after {
+		top: 3px;
+		left: 3px;
+		width: 15px;
+		height: 15px;
+	}
+
+
+	#color-mode-switch input:checked + label:after {
+		left: calc(100% - 3px);
+	}
+}

--- a/css/global.css
+++ b/css/global.css
@@ -63,7 +63,7 @@ html, body {
 }
 
 #doc blockquote {
-  border-left: var(--color-divider);
+  border-color: var(--color-divider);
 }
 
 /*

--- a/css/global.css
+++ b/css/global.css
@@ -61,6 +61,8 @@ html, body {
 
 /*
 	Tables
+	- Optional: add 'transparent' class to create an invisible table, remove borders, striping and background, usually for tablegird layouts
+	- Optional: add 'centered' class to center align all the text within the table
 */
 #doc table thead tr, #doc table tr.header {
 	background-color: var(--color-table-row-header);
@@ -78,15 +80,37 @@ html, body {
 	border-color: var(--color-table-border);
 }
 
+#doc table.transparent,
+#doc table.transparent th,
+#doc table.transparent td,
+#doc table.transparent thead tr, #doc table.borderless tr.header,
+#doc table.transparent tbody tr, #doc table.borderless  tr.odd,
+#doc table.transparent tbody tr:nth-child(2n), #doc table.borderless tr.even {
+	border: none;
+	background-color: transparent;
+}
+
+#doc table.centered,
+#doc table.centered th,
+#doc table.centered td {
+	text-align: center;
+}
+
 /*
 	Images
+	- Optional: add 'transparent' class to remove the border and white background, useful to preserve transparent background images
 	- Optional: add 'padded' class to give extra padding to an image
 	- Optional: add 'invert' class to the image for dark mode inversion
-*/
+	*/
 #doc img {
 	box-sizing: border-box;
 	border: 1px solid var(--color-divider);
 	border-radius: 3px;
+}
+
+#doc img.transparent {
+	border: none;
+	background-color: transparent;
 }
 
 #doc img.padded {

--- a/css/global.css
+++ b/css/global.css
@@ -1,83 +1,83 @@
 /*
-	Light Color Scheme
+  Light Color Scheme
 */
 :root {
-	--color-text: #333;
-	--color-bg: #fafafa;
-	--color-heading: #333;
-	--color-divider: #cdcdcd;
-	--color-anchor: #337ab7;
-	--color-toggle-accent: #c3a554;
-	--color-table-row-header: #e8e6e6;
-	--color-table-row-odd: #fbfbfb;
-	--color-table-row-even: #f0f0f0;
-	--color-table-border: #c2c2c2;
+  --color-bg: #fafafa;
+  --color-text: #333;
+  --color-heading: #333;
+  --color-anchor: #337ab7;
+  --color-divider: #cdcdcd;
+  --color-toggle-accent: #c3a554;
+  --color-table-row-header: #e8e6e6;
+  --color-table-row-odd: #fbfbfb;
+  --color-table-row-even: #f0f0f0;
+  --color-table-border: #c2c2c2;
 }
 
 /*
-	Dark Color Scheme
+  Dark Color Scheme
 */
 html.dark {
-	--color-text: #fafafa;
-	--color-bg: #1c1c1c;
-	--color-heading: #dfdfdf;
-	--color-divider: #8b8b8b;
-	--color-anchor: #77e1cd;
-	--color-toggle-accent: #a076ce;
-	--color-table-row-header: #000;
-	--color-table-row-odd: #333333;
-	--color-table-row-even: #181818;
-	--color-table-border: #767676;
+  --color-bg: #1c1c1c;
+  --color-text: #fafafa;
+  --color-heading: #dfdfdf;
+  --color-anchor: #77e1cd;
+  --color-divider: #8b8b8b;
+  --color-toggle-accent: #a076ce;
+  --color-table-row-header: #000;
+  --color-table-row-odd: #333333;
+  --color-table-row-even: #181818;
+  --color-table-border: #767676;
 }
 
 /*
-	Apply colors to general doc selectors
+  Apply colors to general doc selectors
 */
 html, body {
-	background-color: var(--color-bg);
-	color: var(--color-text);
+  background-color: var(--color-bg);
+  color: var(--color-text);
 }
 
 #doc h1, #doc h2, #doc h3, #doc h4, #doc h5, #doc h6 {
-	color: var(--color-heading);
-	border-color: var(--color-divider);
+  color: var(--color-heading);
+  border-color: var(--color-divider);
 }
 
 #doc, #doc div, #doc span, #doc p, #doc li, #doc th, #doc td, #doc dd, #doc dl {
-	color: var(--color-text);
+  color: var(--color-text);
 }
 
 #doc a:link, #doc a:visited, #doc a:active, #doc a:checked {
-	color: var(--color-anchor);
+  color: var(--color-anchor);
 }
 
 #doc hr {
-	background-color: var(--color-divider);
+  background-color: var(--color-divider);
 }
 
 #doc blockquote {
-	border-left: var(--color-divider);
+  border-left: var(--color-divider);
 }
 
 /*
-	Tables
-	- Optional: add 'transparent' class to create an invisible table, remove borders, striping and background, usually for tablegird layouts
-	- Optional: add 'centered' class to center align all the text within the table
+  Tables
+  - Optional: add 'transparent' class to create an invisible table, remove borders, striping and background, usually for tablegird layouts
+  - Optional: add 'centered' class to center align all the text within the table
 */
 #doc table thead tr, #doc table tr.header {
-	background-color: var(--color-table-row-header);
+  background-color: var(--color-table-row-header);
 }
 
 #doc table tbody tr, #doc table tr.odd {
-	background-color: var(--color-table-row-odd);
+  background-color: var(--color-table-row-odd);
 }
 
 #doc table tbody tr:nth-child(2n), #doc table tr.even {
-	background-color: var(--color-table-row-even);
+  background-color: var(--color-table-row-even);
 }
 
 #doc table th, #doc table td {
-	border-color: var(--color-table-border);
+  border-color: var(--color-table-border);
 }
 
 #doc table.transparent,
@@ -86,97 +86,98 @@ html, body {
 #doc table.transparent thead tr, #doc table.borderless tr.header,
 #doc table.transparent tbody tr, #doc table.borderless  tr.odd,
 #doc table.transparent tbody tr:nth-child(2n), #doc table.borderless tr.even {
-	border: none;
-	background-color: transparent;
+  border: none;
+  background-color: transparent;
 }
 
 #doc table.centered,
 #doc table.centered th,
 #doc table.centered td {
-	text-align: center;
+  text-align: center;
 }
 
 /*
-	Images
-	- Optional: add 'transparent' class to remove the border and white background, useful to preserve transparent background images
-	- Optional: add 'padded' class to give extra padding to an image
-	- Optional: add 'invert' class to the image for dark mode inversion
-	*/
+  Images
+  - Optional: add 'transparent' class to remove the border & background, useful to preserve transparent background images/icons
+  - Optional: add 'padded' class to give extra padding to an image
+  - Optional: add 'invert' class to the image for dark mode inversion
+*/
 #doc img {
-	box-sizing: border-box;
-	border: 1px solid var(--color-divider);
-	border-radius: 3px;
+  box-sizing: border-box;
+  border: 1px solid var(--color-divider);
+  border-radius: 3px;
 }
 
 #doc img.transparent {
-	border: none;
-	background-color: transparent;
+  border: none;
+  background-color: transparent;
 }
 
 #doc img.padded {
-	padding: 12px;
+  padding: 12px;
 }
 
 html.dark #doc img.invert {
-	filter: invert(1)
+  filter: invert(1)
 }
 
 /*
-	Color Scheme Toggle Switch
+  Color Scheme Toggle Switch
+  - Styled checkbox with slight animation when toggling
 */
 #color-mode-switch {
-	display: flex;
-	align-items: center;
-	justify-content: flex-end;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
 }
 
 #color-mode-switch > span {
-	font-size: 30px;
-	display: inline-block;
-	margin-right: 8px;
+  font-size: 30px;
+  display: inline-block;
+  margin-right: 8px;
 }
 
 #color-mode-switch svg {
-	width: 24px;
-	height: 24px;
-	margin: 0 4px;
+  width: 24px;
+  height: 24px;
+  margin: 0 4px;
 }
 
 #color-mode-switch input[type=checkbox] {
-	height: 0;
-	width: 0;
-	visibility: hidden;
+  height: 0;
+  width: 0;
+  visibility: hidden;
 }
 
 #color-mode-switch label {
-	cursor: pointer;
-	text-indent: -9999px;
-	width: 42px;
-	height: 21px;
-	border-radius: 30px;
-	background: var(--color-toggle-accent);
-	display: block;
-	position: relative;
-	margin: 0;
+  cursor: pointer;
+  text-indent: -9999px;
+  width: 42px;
+  height: 21px;
+  border-radius: 30px;
+  background: var(--color-toggle-accent);
+  display: block;
+  position: relative;
+  margin: 0;
 }
 
 #color-mode-switch label:after {
-	content: '';
-	position: absolute;
-	top: 3px;
-	left: 3px;
-	width: 15px;
-	height: 15px;
-	background: #fff;
-	border-radius: 90px;
-	transition: 0.3s;
+  content: '';
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 15px;
+  height: 15px;
+  background: #fff;
+  border-radius: 90px;
+  transition: 0.3s;
 }
 
 #color-mode-switch input:checked + label:after {
-	left: calc(100% - 3px);
-	transform: translateX(-100%);
+  left: calc(100% - 3px);
+  transform: translateX(-100%);
 }
 
 #color-mode-switch label:active:after {
-	width: 30px;
+  width: 30px;
 }

--- a/css/global.css
+++ b/css/global.css
@@ -5,7 +5,7 @@
 	--color-text: #333;
 	--color-bg: #fafafa;
 	--color-heading: #333;
-	--color-divider: #e2e2e2;
+	--color-divider: #cdcdcd;
 	--color-anchor: #337ab7;
 	--color-toggle-accent: #c3a554;
 	--color-table-row-header: #e8e6e6;
@@ -55,11 +55,8 @@ html, body {
 	background-color: var(--color-divider);
 }
 
-#doc img {
-	padding: 12px;
-	background-color: #fff;
-	border: 1px solid var(--color-divider);
-	border-radius: 3px;
+#doc blockquote {
+	border-left: var(--color-divider);
 }
 
 /*
@@ -82,9 +79,20 @@ html, body {
 }
 
 /*
-	Dark Mode Images
+	Images
+	- Optional: add 'padded' class to give extra padding to an image
 	- Optional: add 'invert' class to the image for dark mode inversion
 */
+#doc img {
+	border: 1px solid var(--color-divider);
+	border-radius: 3px;
+}
+
+#doc img.padded {
+	padding: 12px;
+	background-color: #fff;
+}
+
 html.dark #doc img.invert {
 	filter: invert(1)
 }

--- a/publish.py
+++ b/publish.py
@@ -53,14 +53,14 @@ MathJax = {
 <div id="doc" class="container-fluid markdown-body comment-enabled" data-hard-breaks="true">
 
 <div id="color-mode-switch">
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
-    </svg>
-    <input type="checkbox" id="switch" />
-    <label for="switch">Dark Mode Toggle</label>
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
-    </svg>
+  <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+  </svg>
+  <input type="checkbox" id="switch" />
+  <label for="switch">Dark Mode Toggle</label>
+  <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+  </svg>
 </div>
 """
 

--- a/publish.py
+++ b/publish.py
@@ -53,9 +53,14 @@ MathJax = {
 <div id="doc" class="container-fluid markdown-body comment-enabled" data-hard-breaks="true">
 
 <div id="color-mode-switch">
-    <span>Enable Dark Mode</span>
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+    </svg>
     <input type="checkbox" id="switch" />
     <label for="switch">Dark Mode Toggle</label>
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+    </svg>
 </div>
 """
 


### PR DESCRIPTION
# General Changes
- Adds in toggle markup that appears in top right of the header of each page
- Adds in styles for a clean look over the checkbox toggle in `global.css`
  - Utilizes CSS variables and styles the elements within the `#doc` container to use these variables for colors
  - There's a separate set for light and dark, which makes it easy to update these for a particular palette
- Adds in support to remember what a user's chosen preferred color scheme is by storing their choice in `localStorage`
- Adds in a the JavaScript needed to add the interactivity for the toggle switch and the styles
  - Checks `localStorage` for any previous saved value and applies it if so - defaults to light for new visitors
  - Toggles the global `dark` class on toggle switch click
  - Updates `localStorage` with the newly selected value
- Adds in a set of utility classes to use during markdown authoring, primarily for use on images and tables

## Notes

I've added in utility classes for images and tables.

- `centered` for centering all text within a table
- `transparent` for invisible tables vs the striped style - applied when tables are used for grid layouts
- `transparent` for images - applied when wanting to preserve a transparent background image - the image will inherit the light/dark mode background color
- `padded` for images - used to apply 12px of padding around an image to give it more room - great for graphs
- `invert` for images - used when wanting to completely invert the colors of an image for dark mode

## Demo

I've created a version that mimics https://vitalik.ca in dark mode, and additionally have applied these utility classes to the images and tables throughout the posts as outlined in https://github.com/vbuterin/blog/pull/40.

View the demo [here](https://vb-dark-mode.surge.sh).